### PR TITLE
feat: Add frontend interface to DataAPI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "csvtojson": "^2.0.10",
         "dotenv": "^8.2.0",
+        "ejs": "^3.1.10",
         "express": "^4.17.1",
         "express-rate-limit": "^5.1.3",
         "express-validator": "^7.2.1",
@@ -1717,6 +1718,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -1854,7 +1861,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -2668,6 +2674,21 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.222",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
@@ -2990,6 +3011,36 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -3822,6 +3873,23 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -5615,7 +5683,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cors": "^2.8.5",
     "csvtojson": "^2.0.10",
     "dotenv": "^8.2.0",
+    "ejs": "^3.1.10",
     "express": "^4.17.1",
     "express-rate-limit": "^5.1.3",
     "express-validator": "^7.2.1",

--- a/public/js/Tools.js
+++ b/public/js/Tools.js
@@ -1,0 +1,22 @@
+const Tools = {
+    showArrayOnDOM: (arr, domId) => {
+        const list = document.getElementById(domId);
+        list.innerHTML = '';
+        arr.forEach(item => {
+            const li = document.createElement('li');
+            li.textContent = JSON.stringify(item);
+            list.appendChild(li);
+        });
+    },
+    getDOMSelectedOption: (sel) => {
+        return sel.options[sel.selectedIndex];
+    },
+    fillForm: (formId, data) => {
+        const form = document.getElementById(formId);
+        for (const key in data) {
+            if (form.elements[key]) {
+                form.elements[key].value = data[key];
+            }
+        }
+    }
+};

--- a/routes/api.routes.js
+++ b/routes/api.routes.js
@@ -15,6 +15,20 @@ router.get('/', (req, res) => {
     });
 });
 
+router.get('/frontend', async (req, res) => {
+    try {
+        const users = await User.find();
+        const devices = await Device.find();
+        res.render('index', {
+            users: users,
+            devices: devices,
+            alarms: []
+        });
+    } catch (err) {
+        res.status(500).send(err);
+    }
+});
+
 
 
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <%- include('partials/mainHead', { title: 'SBQC ' }) %>
+
+</head>
+
+
+
+
+<body class="fixed-nav sticky-footer bg-light sidenav-toggled" id="page-top">
+
+<%- include('partials/nav') %>
+
+
+<div class="content-wrapper">
+    <div class="container-fluid bg-3 text-center">
+
+        <div class='row'>
+            <div class='col-sm-8 mx-auto'>
+                <div class="card text-center">
+                    <div class='card-body form-inline'>
+
+                        <select class='form-control' style='width:280px' id="user_select" selected ></select>
+
+                        <form>
+                            <div class="form-group form-inline">
+                                <button type="button" onClick="selectUser()" class="btn btn-primary mx-2 ">Select User</button>
+                            </div>
+
+                            <input type="hidden" id="sender_id" name="sender" value="">
+                            <!-- <input type="hidden" id="io_id" name="io_id" value=""> -->
+                        </form>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row my-2">
+
+            <div class='col-sm-8 mx-auto'>
+                <div class="card">
+                    <div class='card-body'>
+                        <form name='userForm' id='userForm'>
+
+                            <div class="form-group">
+                            <label for="name">Name</label>
+                            <input type="text" class="form-control" id="name" name='name' aria-describedby="emailHelp" placeholder="Enter name">
+                            </div>
+                            <div class="form-group">
+                            <label for="email">Email address</label>
+                            <input type="email" class="form-control" id="email" name='email' aria-describedby="emailHelp" placeholder="Enter email">
+                            <small id="emailHelp" class="form-text text-muted">emails are not shared.</small>
+                            </div>
+                            <div class="form-group">
+                            <label for="exampleInputPassword">Password</label>
+                            <input type="password" class="form-control" id="exampleInputPassword" name='password' placeholder="Password">
+                            </div>
+
+                            <div class="row">
+                                <div class="form-group mx-2">
+                                    <label for="lat">Latitude</label>
+                                    <input class='form-control mr-2' type="text" id="lat" name="lat" placeholder="00.00">
+                                </div>
+                                <div class="form-group mx-2">
+                                    <label for="lon">Longitude</label>
+                                    <input class='form-control' type="text" id="lon" name='lon' placeholder="00.00">
+                                </div>
+                            </div>
+
+                            <div class='row'>
+                                <div class="form-group mx-2">
+                                    <label for="creationDate">Creation</label>
+                                    <input class='form-control mr-2' type="text" id="creationDate" name='creationDate' placeholder="2020/01/01">
+                                </div>
+                                <div class="form-group mx-2">
+                                    <label for="lastConnectDate">Last Connection</label>
+                                    <input class='form-control' type="text" id="lastConnectDate" name='lastConnectDate' placeholder="2020/03/01">
+                                </div>
+                            </div>
+
+                            <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="exampleCheck1">
+                            <label class="form-check-label" for="exampleCheck1">Check me out</label>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Submit</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+
+        <div class="row">
+            <div class="col-sm-8 mx-auto">
+                <div class="card my-5 ">
+                <div class="card-body ">
+                    <form class="form-signin" action ="/user/deleteViaEmail" method="post" enctype="application/json" >
+                        <div class="input-group">
+                            <input type="email" class="form-control"  name='email' id="email_id" placeholder="Email address" required autofocus>
+                            <span class="input-group-btn mx-2">
+                                    <button class="btn btn-md btn-warning btn-block text-uppercase" type="submit">Delete User</button>
+                            </span>
+                        </div>
+                    </form>
+                </div>
+
+                <div class='card text-center'>
+                    <div class='card-body'>
+                        <form action="/resetDB">
+                            <button class="btn btn-md btn-warning btn-block text-uppercase" type="submit">!!!!  Reset DB !!!!</button>
+                        </form>
+                    </div>
+                </div>
+
+                </div>
+            </div>
+        </div>
+
+         <div class="row">
+            <div class='col-sm-12'>
+                <div class="card">
+                    <div class='card-body text-left'>
+                        <small><div id='deviceList'></div></small>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+
+
+
+        <div class='row'>
+            <div class='col-sm-8 mx-auto'>
+                <div class="card text-center">
+                    <div class='card-body form-inline'>
+
+                        <select class='form-control' style='width:280px' id="device_select" selected ></select>
+
+                        <form>
+                            <div class="form-group form-inline">
+                                <button type="button" onClick="selectDevice()" class="btn btn-primary mx-2 ">Select Device</button>
+                            </div>
+
+                            <input type="hidden" id="device_id" name="device" value="">
+                        </form>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+
+        <div class="row my-2">
+
+            <div class='col-sm-8 mx-auto'>
+                <div class="card">
+                    <div class='card-body'>
+                        <form name='deviceForm' id='deviceForm'>
+
+                            <div class="form-group">
+                                <label for="type">Type</label>
+                                <input type="text" class="form-control" id="type" name='type' aria-describedby="emailHelp" placeholder="Enter name">
+                            </div>
+                            <div class="form-group">
+                                <label for="id">UID</label>
+                                <input type="text" class="form-control" id="id" name='id'>
+                            </div>
+                            <div class='row'>
+                                <div class="form-group mx-2">
+                                    <label for="lastBoot">Last boot</label>
+                                    <input class='form-control mr-2' type="text" id="lastBoot" name='lastBoot' placeholder="2020/01/01 XX:XX:XX">
+                                </div>
+                                <div class="form-group mx-2">
+                                    <label for="connected">Connected</label>
+                                    <input class='form-control' type="text" id="connected" name='connected' placeholder="true">
+                                </div>
+                            </div>
+
+                            <button type="submit" class="btn btn-primary">Submit</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+
+ <!-- End Container  -->
+</div>
+</div>
+
+<%- include('partials/footer') %>
+
+
+<script>
+    const userList = <%-JSON.stringify(users)%>
+    console.log("userlist: ", userList)
+
+    const deviceList = <%-JSON.stringify(devices)%>
+    console.log("devicelist: " , deviceList)
+    /*
+    const alarmList = <%-JSON.stringify(alarms)%>
+    console.log("alarmlist: ", alarmList)
+    */
+
+
+    async function setUserList()
+    {
+        let select = document.getElementById('user_select');
+        for(let index in userList) {
+                select.options[select.options.length] = new Option(userList[index].email, index);
+        }
+
+
+
+
+
+    }
+    setUserList()
+
+    async function setDeviceList()
+    {
+        let select = document.getElementById('device_select');
+        for(let index in deviceList) {
+                select.options[select.options.length] = new Option(deviceList[index].id, index);
+        }
+    }
+    setDeviceList()
+
+    Tools.showArrayOnDOM(deviceList, "deviceList")
+
+    function selectUser()
+    {
+      var sel = document.getElementById('user_select');
+        for(let index in userList)
+        {
+            let selected = Tools.getDOMSelectedOption(sel)
+            if(userList[index].email ==  selected.innerHTML)
+            {
+              console.log(userList[index])
+              Tools.fillForm('userForm', userList[index])
+            }
+        }
+    }
+
+    function selectDevice()
+    {
+      var sel = document.getElementById('device_select');
+        for(let index in deviceList)
+        {
+            let selected = Tools.getDOMSelectedOption(sel)
+            if(deviceList[index].id ==  selected.innerHTML)
+            {
+              console.log(deviceList[index])
+              Tools.fillForm('deviceForm', deviceList[index])
+            }
+        }
+    }
+
+
+
+                          /*    function update(id, data){
+                                fetch('http://localhost:3001/api/user/' + id, {
+                                  method: 'PATCH',
+                                  body: JSON.stringify({ data })
+                                }).then((response) => {
+                                  response.json().then((response) => {
+                                    console.log(response);
+                                  })
+                                }).catch(err => {
+                                  console.error(err)
+                                })
+
+                              }*/
+
+
+    </script>
+
+
+</body>
+</html>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,0 +1,11 @@
+<footer class="sticky-footer">
+    <div class="container">
+        <div class="text-center">
+            <small>Copyright © Your Website 2023</small>
+        </div>
+    </div>
+</footer>
+<!-- Bootstrap core JavaScript-->
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>

--- a/views/partials/mainHead.ejs
+++ b/views/partials/mainHead.ejs
@@ -1,0 +1,9 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta name="description" content="">
+<meta name="author" content="">
+<title><%= title %></title>
+<!-- Bootstrap core CSS-->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+<script src="/js/Tools.js"></script>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -1,0 +1,3 @@
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
+    <a class="navbar-brand" href="/">DataAPI</a>
+</nav>


### PR DESCRIPTION
This commit introduces a new frontend to the DataAPI, built with EJS.

- Configured the Express server to use EJS as the view engine and serve static files.
- Created a new `/frontend` route that renders the main page with user and device data.
- Added EJS templates for the main page and partials for the head, navigation, and footer.
- Included a client-side JavaScript file (`Tools.js`) for DOM manipulation.
- Added `ejs` as a dependency.
- Configured the application to use an in-memory MongoDB server for development when a `MONGO_URL` is not provided.