### PR TITLE
feat: Add user management page

### DIFF
--- a/routes/web.routes.js
+++ b/routes/web.routes.js
@@ -16,4 +16,16 @@ router.get('/', async (req, res) => {
     }
 });
 
+router.get('/users', async (req, res) => {
+    try {
+        const users = await User.find();
+        res.render('users', {
+            users: users,
+            title: 'User Management'
+        });
+    } catch (err) {
+        res.status(500).send(err);
+    }
+});
+
 module.exports = router;

--- a/tests/user_page.test.js
+++ b/tests/user_page.test.js
@@ -1,0 +1,49 @@
+const request = require('supertest');
+const app = require('../data_serv.js'); // Adjust this path if needed
+const User = require('../models/userModel');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+describe('User Page', () => {
+    let mongoServer;
+
+    beforeAll(async () => {
+        mongoServer = await MongoMemoryServer.create();
+        const mongoUri = mongoServer.getUri();
+        await mongoose.connect(mongoUri, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+        });
+    });
+
+    afterAll(async () => {
+        await mongoose.disconnect();
+        await mongoServer.stop();
+    });
+
+    beforeEach(async () => {
+        await User.deleteMany({});
+    });
+
+    it('should return 200 OK and render the user management page', async () => {
+        const res = await request(app).get('/users');
+        expect(res.statusCode).toEqual(200);
+        expect(res.text).toContain('User Management');
+    });
+
+    it('should create a new user and return a 201 status code', async () => {
+        const res = await request(app)
+            .post('/api/v1/users')
+            .send({
+                name: 'Test User',
+                email: 'test@example.com',
+                password: 'password123',
+            });
+
+        expect(res.statusCode).toEqual(201);
+
+        const user = await User.findOne({ email: 'test@example.com' });
+        expect(user).not.toBeNull();
+        expect(user.name).toBe('Test User');
+    });
+});

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -1,3 +1,22 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
     <a class="navbar-brand" href="/">DataAPI</a>
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarResponsive">
+        <ul class="navbar-nav navbar-sidenav" id="exampleAccordion">
+            <li class="nav-item" data-toggle="tooltip" data-placement="right" title="Dashboard">
+                <a class="nav-link" href="/">
+                    <i class="fa fa-fw fa-dashboard"></i>
+                    <span class="nav-link-text">Dashboard</span>
+                </a>
+            </li>
+            <li class="nav-item" data-toggle="tooltip" data-placement="right" title="Users">
+                <a class="nav-link" href="/users">
+                    <i class="fa fa-fw fa-users"></i>
+                    <span class="nav-link-text">Users</span>
+                </a>
+            </li>
+        </ul>
+    </div>
 </nav>

--- a/views/users.ejs
+++ b/views/users.ejs
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <%- include('partials/mainHead', { title: title }) %>
+</head>
+
+<body class="fixed-nav sticky-footer bg-light sidenav-toggled" id="page-top">
+
+    <%- include('partials/nav') %>
+
+    <div class="content-wrapper">
+        <div class="container-fluid">
+
+            <!-- Breadcrumbs-->
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">
+                    <a href="/">Dashboard</a>
+                </li>
+                <li class="breadcrumb-item active">Users</li>
+            </ol>
+
+            <div class="row">
+                <div class="col-12">
+                    <h1><%= title %></h1>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header">
+                    <i class="fa fa-user-plus"></i> Create New User
+                </div>
+                <div class="card-body">
+                    <form id="createUserForm">
+                        <div class="form-row">
+                            <div class="form-group col-md-4">
+                                <label for="name">Name</label>
+                                <input type="text" class="form-control" id="name" name="name" placeholder="Name" required>
+                            </div>
+                            <div class="form-group col-md-4">
+                                <label for="email">Email</label>
+                                <input type="email" class="form-control" id="email" name="email" placeholder="Email" required>
+                            </div>
+                            <div class="form-group col-md-4">
+                                <label for="password">Password</label>
+                                <input type="password" class="form-control" id="password" name="password" placeholder="Password" required>
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Create User</button>
+                    </form>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-header">
+                    <i class="fa fa-users"></i> Existing Users
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Email</th>
+                                    <th>Created At</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <% users.forEach(function(user) { %>
+                                    <tr>
+                                        <td><%= user.name %></td>
+                                        <td><%= user.email %></td>
+                                        <td><%= user.created %></td>
+                                    </tr>
+                                <% }); %>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        <!-- /.container-fluid-->
+    </div>
+    <!-- /.content-wrapper-->
+
+    <%- include('partials/footer') %>
+
+    <script>
+        document.getElementById('createUserForm').addEventListener('submit', async (event) => {
+            event.preventDefault();
+
+            const form = event.target;
+            const formData = new FormData(form);
+            const data = Object.fromEntries(formData.entries());
+
+            try {
+                const response = await fetch('/api/v1/users', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(data)
+                });
+
+                if (response.ok) {
+                    location.reload();
+                } else {
+                    const error = await response.json();
+                    alert(`Error: ${error.message}`);
+                }
+            } catch (error) {
+                console.error('Error creating user:', error);
+                alert('An error occurred while creating the user.');
+            }
+        });
+    </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
This commit introduces a new page for user management, allowing users to view a list of existing users and create new ones.

The new page is available at `/users` and includes a form for creating new users and a table for displaying existing users. The page is built using EJS and is integrated with the existing backend API for user creation.

A new test suite has been added to verify the functionality of the new page.

Note: This feature relies on the existing backend API for user creation at `POST /api/v1/users`. The backend logic for this API is not included in this patch.