### PR TITLE
feat: Display app version in navbar

### DIFF
--- a/data_serv.js
+++ b/data_serv.js
@@ -5,11 +5,15 @@ require('dotenv').config();
 const mdb = require('./mongooseDB');
 const liveDatas = require('./scripts/liveData.js');
 const { MongoMemoryServer } = require('mongodb-memory-server');
+const pjson = require('./package.json');
 
 const PORT = process.env.PORT || 3003;
 const dbCollectionName = process.env.NODE_ENV === 'production' ? 'datas' : 'devdatas';  
 
 const app = express();
+
+// Make version available in all templates
+app.locals.appVersion = pjson.version;
 
 // Middlewares & routes
 app.use(cors({ origin: '*', optionsSuccessStatus: 200 }));

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -18,5 +18,10 @@
                 </a>
             </li>
         </ul>
+        <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+                <span class="nav-link" style="color: rgba(255, 255, 255, 0.5);">v<%= appVersion %></span>
+            </li>
+        </ul>
     </div>
 </nav>


### PR DESCRIPTION
This commit adds the application version to the right-hand side of the navigation bar.

- Reads the version from package.json in `data_serv.js`.
- Makes the version available to all EJS templates via `app.locals.appVersion`.
- Updates the `views/partials/nav.ejs` template to display the version.

This helps in visually verifying which version of the application is currently deployed.