### PR TITLE
fix(js): Resolve MDBootstrap initialization error

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -5,3 +5,9 @@
         </div>
     </div>
 </footer>
+
+<!-- MDB -->
+<script
+  type="text/javascript"
+  src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.2.0/mdb.umd.min.js"
+></script>

--- a/views/partials/mainHead.ejs
+++ b/views/partials/mainHead.ejs
@@ -21,11 +21,6 @@
   rel="stylesheet"
 />
 
-<!-- MDB -->
-<script
-  type="text/javascript"
-  src="https://cdnjs.cloudflare.com/ajax/libs/mdb-ui-kit/7.2.0/mdb.umd.min.js"
-></script>
 
 <!-- <script src="/js/Tools.js"></script> -->
 <!-- The Tools.js script has been refactored into modern ES6 modules. -->


### PR DESCRIPTION
Moves the MDBootstrap JavaScript `<script>` tag from the `<head>` to the end of the `<body>`. This resolves a race condition where the script would execute before the DOM was fully loaded, causing a `TypeError: Cannot read properties of null (reading 'hasAttribute')`.

By relocating the script, we ensure that all DOM elements are available for MDBootstrap to query and initialize its components, preventing the error and allowing the dashboard to render correctly.