### PR TITLE
Normalize file path handling, validate batch storage paths, and accept text TLE responses

### DIFF
--- a/controllers/fileBrowserController.js
+++ b/controllers/fileBrowserController.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { formatFileSize } = require('../utils/file-operations');
 const { BadRequestError, NotFoundError } = require('../utils/errors');
 
@@ -79,7 +80,7 @@ class FileBrowserController {
       // Format results
       const formattedResults = results.map(file => ({
         ...file,
-        path: file.dirname + file.filename,
+        path: FileBrowserController._formatFilePath(file),
         sizeFormatted: formatFileSize(file.size),
         mtimeFormatted: new Date(file.mtime * 1000).toISOString()
       }));
@@ -349,7 +350,7 @@ class FileBrowserController {
               message: `Found ${largeFiles.length} files over 100MB`,
               potentialSavings: largeFiles.reduce((sum, f) => sum + f.size, 0),
               files: largeFiles.map(f => ({
-                path: f.dirname + f.filename,
+                path: FileBrowserController._formatFilePath(f),
                 size: f.size,
                 sizeFormatted: formatFileSize(f.size)
               }))
@@ -359,7 +360,7 @@ class FileBrowserController {
               priority: 'medium',
               message: `Found ${oldFiles.length} files older than 2 years`,
               files: oldFiles.map(f => ({
-                path: f.dirname + f.filename,
+                path: FileBrowserController._formatFilePath(f),
                 age: Math.floor((Date.now() / 1000 - f.mtime) / 86400) + ' days',
                 size: formatFileSize(f.size)
               }))
@@ -395,6 +396,16 @@ class FileBrowserController {
     const boundaries = [0, 1024, 10240, 102400, 1048576, 10485760, 104857600];
     const index = boundaries.indexOf(boundary);
     return labels[index] || 'other';
+  }
+
+  static _formatFilePath(file) {
+    if (file.path) {
+      return file.path;
+    }
+    if (!file.dirname) {
+      return file.filename || '';
+    }
+    return path.join(file.dirname, file.filename || '');
   }
 
   // ==========================================

--- a/controllers/fileExportController.js
+++ b/controllers/fileExportController.js
@@ -32,6 +32,16 @@ class OptimizedExportController {
         this.nasDirectories = db.collection('nas_directories');
     }
 
+    static formatFilePath(file) {
+        if (file.path) {
+            return file.path;
+        }
+        if (!file.dirname) {
+            return file.filename || '';
+        }
+        return path.join(file.dirname, file.filename || '');
+    }
+
     /**
      * Generate optimized full report
      */
@@ -51,7 +61,7 @@ class OptimizedExportController {
             const file = await cursor.next();
 
             // Reconstruct path from dirname + filename
-            const fullPath = (file.dirname || '') + '/' + (file.filename || '');
+            const fullPath = OptimizedExportController.formatFilePath(file);
 
             files.push({
                 path: fullPath,
@@ -156,7 +166,7 @@ class OptimizedExportController {
             const file = await cursor.next();
 
             mediaFiles.push({
-                path: (file.dirname || '') + '/' + (file.filename || ''),
+                path: OptimizedExportController.formatFilePath(file),
                 filename: file.filename,
                 dirname: file.dirname,
                 ext: file.ext,
@@ -195,7 +205,7 @@ class OptimizedExportController {
             const file = await cursor.next();
 
             largeFiles.push({
-                path: (file.dirname || '') + '/' + (file.filename || ''),
+                path: OptimizedExportController.formatFilePath(file),
                 filename: file.filename,
                 dirname: file.dirname,
                 ext: file.ext,

--- a/controllers/storageController.js
+++ b/controllers/storageController.js
@@ -304,9 +304,18 @@ const insertBatch = async (req, res, next) => {
     const filesCollection = db.collection('nas_files');
     const now = new Date();
     
+    for (const [index, file] of files.entries()) {
+      if (!file || typeof file.path !== 'string' || file.path.trim() === '') {
+        return res.status(400).json({
+          status: 'error',
+          message: `files[${index}].path must be a non-empty string`
+        });
+      }
+    }
+
     const bulkOps = files.map(file => {
       // Normalize path (remove trailing slashes, etc.)
-      const normalizedPath = file.path?.replace(/\/+$/, '').trim();
+      const normalizedPath = file.path.replace(/\/+$/, '').trim();
       
       // Extract filename and extension
       const pathParts = normalizedPath?.split('/') || [];
@@ -323,6 +332,7 @@ const insertBatch = async (req, res, next) => {
               path: normalizedPath,
               dirname,
               filename,
+              ext: extension,
               extension,
               size: file.size || 0,
               modified: file.mtime ? new Date(file.mtime * 1000) : file.modified ? new Date(file.modified) : now,

--- a/public/js/file-browser-simple.js
+++ b/public/js/file-browser-simple.js
@@ -150,7 +150,7 @@ const FileBrowser = {
             <small>${formatDate(new Date(file.mtime * 1000))}</small>
           </td>
           <td>
-            <button class="btn btn-sm btn-outline-primary" onclick="FileBrowser.showFileDetails('${this.escapeHtml(file.dirname)}', '${this.escapeHtml(file.filename)}')">
+            <button class="btn btn-sm btn-outline-primary" onclick="FileBrowser.showFileDetails('${this.escapeHtml(file.dirname)}', '${this.escapeHtml(file.filename)}', '${this.escapeHtml(file.path || '')}')">
               <i class="fa fa-info-circle"></i>
             </button>
           </td>
@@ -283,9 +283,9 @@ const FileBrowser = {
     return 'fa-file';
   },
 
-  showFileDetails(dirname, filename) {
+  showFileDetails(dirname, filename, fullPath) {
     const modalBody = document.getElementById('fileDetailsBody');
-    const fullPath = dirname + filename;
+    const resolvedPath = fullPath || this.joinPath(dirname, filename);
     
     modalBody.innerHTML = `
       <div class="row">
@@ -298,7 +298,7 @@ const FileBrowser = {
       </div>
       <div class="row mt-2">
         <div class="col-md-4"><strong>Full Path:</strong></div>
-        <div class="col-md-8"><code>${this.escapeHtml(fullPath)}</code></div>
+        <div class="col-md-8"><code>${this.escapeHtml(resolvedPath)}</code></div>
       </div>
     `;
     
@@ -318,6 +318,14 @@ const FileBrowser = {
     const div = document.createElement('div');
     div.textContent = text;
     return div.innerHTML;
+  },
+
+  joinPath(dirname, filename) {
+    if (!dirname) {
+      return filename || '';
+    }
+    const normalizedDir = dirname.endsWith('/') ? dirname : `${dirname}/`;
+    return `${normalizedDir}${filename || ''}`;
   },
 
   showError(message) {

--- a/public/js/file-browser.js
+++ b/public/js/file-browser.js
@@ -297,7 +297,7 @@ const FileBrowser = {
             <p><strong>Locations:</strong></p>
             <ul class="list-unstyled">
               ${dup.locations.map(loc => `
-                <li><code>${this.escapeHtml(loc.dirname + dup.filename)}</code></li>
+                <li><code>${this.escapeHtml(loc.path || this.joinPath(loc.dirname, dup.filename))}</code></li>
               `).join('')}
             </ul>
           </div>
@@ -384,6 +384,14 @@ const FileBrowser = {
       "'": '&#039;'
     };
     return text.replace(/[&<>"']/g, m => map[m]);
+  },
+
+  joinPath(dirname, filename) {
+    if (!dirname) {
+      return filename || '';
+    }
+    const normalizedDir = dirname.endsWith('/') ? dirname : `${dirname}/`;
+    return `${normalizedDir}${filename || ''}`;
   },
 
   showError(message) {


### PR DESCRIPTION
### Motivation
- Ensure file paths are rendered consistently in the UI and reports so users don't see duplicated or malformed slashes. 
- Prevent crashes or silent bad upserts during batch storage imports by validating incoming file records before normalization. 
- Centralize path construction so server and client compute file paths the same way. 
- Make the Celestrak TLE proxy tolerant of plain-text TLE responses in addition to JSON to avoid parse failures.

### Description
- Add `joinPath` helper to client `FileBrowser` and pass precomputed `file.path` into the details modal to avoid fragile `dirname + filename` concatenation in `public/js/file-browser.js` and `public/js/file-browser-simple.js`.
- Add `_formatFilePath` to `controllers/fileBrowserController.js` and `formatFilePath` to `controllers/fileExportController.js` to consistently compute `path` using `path.join` and replace ad-hoc string concatenation sites.
- Harden batch import in `controllers/storageController.js` by validating `files[index].path` is a non-empty string, removing unsafe optional chaining during normalization, and populating a lowercased `ext` on upserts.
- Add `parseJsonOrText` and extend `proxyRequest` in `controllers/externalApiController.js` to accept a `parseFn`, and wire `parseJsonOrText` into `getTle` so the proxy accepts either JSON or raw text payloads.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcd12279883229ce56bbb10c9d141)